### PR TITLE
Proper transparency support

### DIFF
--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -188,7 +188,7 @@ var/global/list/all_graffitis = list(
 				var/turf/simulated/the_turf = target
 				var/datum/painting_utensil/p = new(user, src)
 				if (!the_turf.advanced_graffiti)
-					var/datum/custom_painting/advanced_graffiti = new(the_turf, 32, 32, base_color = "#aaaaaaff")
+					var/datum/custom_painting/advanced_graffiti = new(the_turf, 32, 32, base_color = "#00000000")
 					the_turf.advanced_graffiti = advanced_graffiti
 				the_turf.advanced_graffiti.interact(user, p)
 

--- a/code/game/turfs/simulated.dm
+++ b/code/game/turfs/simulated.dm
@@ -17,7 +17,7 @@
 		return FALSE
 	overlays -= advanced_graffiti_overlay
 	advanced_graffiti_overlay = advanced_graffiti.render_on(icon(icon, icon_state))
-	advanced_graffiti_overlay.SwapColor("#aaaaaaff", "#ffffff00")
+	//advanced_graffiti_overlay.SwapColor("#aaaaaaff", "#ffffff00")
 	overlays += advanced_graffiti_overlay
 
 /turf/simulated/New()

--- a/code/modules/html_interface/paintTool/canvas.css
+++ b/code/modules/html_interface/paintTool/canvas.css
@@ -17,6 +17,13 @@
 	padding: 20px;
 }
 
+.controlColumnNarrow {
+	overflow: auto;
+	height:100%;
+	width: 100px;
+	padding: 20px;
+}
+
 .controlColumn input[type="text"] {
 	width:100%;
 }
@@ -56,7 +63,7 @@
 }
 
 .canvasPanel canvas {
-	background: #202020;
+	background: #0000;
 	z-index: 1;
 	position: relative;
 }

--- a/code/modules/html_interface/paintTool/canvas.css
+++ b/code/modules/html_interface/paintTool/canvas.css
@@ -17,13 +17,6 @@
 	padding: 20px;
 }
 
-.controlColumnNarrow {
-	overflow: auto;
-	height:100%;
-	width: 100px;
-	padding: 20px;
-}
-
 .controlColumn input[type="text"] {
 	width:100%;
 }

--- a/code/modules/html_interface/paintTool/canvas.js
+++ b/code/modules/html_interface/paintTool/canvas.js
@@ -374,6 +374,9 @@ function initCanvas(paintInitData, canvasInitData) {
 			'<div class="paletteColor" onclick="setColor(\'' + palette[color] + '\');" style="background-image:' +  generateColorPaletteBackgroundStyle(palette[color]) + '; background-image:' +  generateColorPaletteBackgroundStyle(palette[color], true) + '"></div>\n';
 	}
 	setColor(palette[0]);
+
+	//no errors initializing canvas stuff thus far, hide the error message
+	document.getElementById("canvas-error").style.display = "none";
 }
 
 //--------------------------------

--- a/code/modules/html_interface/paintTool/canvas.tmpl
+++ b/code/modules/html_interface/paintTool/canvas.tmpl
@@ -105,7 +105,7 @@
 				<p>Use "<i>Paint Over</i>" to paint a given region with your currently selected color and opacity. Each region usually comes with a color hint you're meant to match (color square to the left of "<i>Paint Over</i>"), and hopefully some text explaining what each region is meant to be (info button).</p>
 				<p>You may move any region to "<i>Done</i>" at any time, so as to get it out of the way if you're done with it, or back to "<i>In Progress</i>" if you need to touch it up again.</p>
 			</div>
-			
+
 			<h3>Info</h3>
 			<!-- Template Size -->
 			<div class="item" id="template_size" style="display: none">
@@ -132,7 +132,7 @@
 			</div>
 			<!-- Warning messages -->
 			<div class="item" id="template_import_warnings" style="display:none"></div>
-			
+
 			<!-- Color region lists -->
 			<h3>In Progress</h3>
 			<ul id="pendingRegions">
@@ -149,7 +149,7 @@
 
 		<!-- Canvas -->
 		<div class="canvasPanel">
-			<p style="">
+			<p id="canvas-error" style="">
 			If you can read this then either your version of Internet Explorer is too old (IE8 or older) or something went wrong.</p>
 			<canvas
 				id="canvas"

--- a/code/modules/html_interface/paintTool/canvas_tile.tmpl
+++ b/code/modules/html_interface/paintTool/canvas_tile.tmpl
@@ -154,7 +154,7 @@
 
 		<!-- Canvas -->
 		<div class="canvasPanel">
-			<p style="">
+			<p id="canvas-error" style="">
 			If you can read this then either your version of Internet Explorer is too old (IE8 or older) or something went wrong.</p>
 			<canvas
 				id="canvas"

--- a/code/modules/html_interface/paintTool/paintTool.js
+++ b/code/modules/html_interface/paintTool/paintTool.js
@@ -267,7 +267,7 @@ function colorOverlayBlend(c1, c2, alpha) {
 function colorRybBlend(c1, c2, alpha) {
 	var c1Ryb = rgbToRyb(c1);
 	var c2Ryb = rgbToRyb(c2);
-	var resultRyb = {r:0, y:0, b:0, a:c2Ryb.a};
+	var resultRyb = {r:0, y:0, b:0, a:Math.min(255.0, c1Ryb.a*alpha + c2Ryb.a)};
 
 	alpha *= c1Ryb.a / 255.0;
 


### PR DESCRIPTION
This should be working fine for transparency. At least it did while testing.
I'm not entirely sure the math on the blend is right, but it works well enough. Of note, the <canvas> object is transparent now, so you could put scaled up floor tile as background or whatever you had in mind there.

I've limited my changes on the .dm side of things to making the base color transparent and commenting out the gray-to-alpha color swap, just to check things work.